### PR TITLE
Allow letter input when caps lock is enabled

### DIFF
--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -45,7 +45,7 @@
 
   function handleKeyDown(event) {
     if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) return;
-    if (letters.has(event.key)) {
+    if (letters.has(event.key.toLowerCase())) {
       dispatch("key", event.key);
     } else if (event.key == "Backspace") {
       dispatch("delete");


### PR DESCRIPTION
I noticed that the (physical) keyboard input did not work when caps lock was enabled. 
So, I just made the event.key lowercase when comparing to the allowed letters.