### PR TITLE
Fixes the view height of the app

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -57,10 +57,6 @@ body,
   @apply min-h-svh;
   touch-action: manipulation;
 }
-body.standalone,
-body.standalone #svelte  {
-  min-height: 100vh;
-}
 
 html {
   @apply h-svh;


### PR DESCRIPTION
When the page is installed as an app on your homescreen, the page becomes too large, making the keyboard being offsetted outside the viewport. Removing the min-height fixes this issue.
Tested on different screen sizes, like iPhone SE, computer screen, and it looks fine everywhere without the min-height added.

Before:
<img width="590" height="1278" alt="IMG_1700" src="https://github.com/user-attachments/assets/78311e49-64d3-477c-bd7f-161c1aaba4fe" />

After:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/a79a0878-d58e-4224-992f-9fc40c2b1eb6" />
